### PR TITLE
Send the caps before sending the first buffer

### DIFF
--- a/lib/membrane_flv_plugin/muxer.ex
+++ b/lib/membrane_flv_plugin/muxer.ex
@@ -63,6 +63,7 @@ defmodule Membrane.FLV.Muxer do
       }
       |> prepare_to_send(state)
 
+    actions = Keyword.put(actions, :caps, {:output, %Membrane.RemoteStream{content_format: FLV}})
     {{:ok, actions}, state}
   end
 
@@ -167,12 +168,9 @@ defmodule Membrane.FLV.Muxer do
   defp prepare_to_send(segment, state) do
     {tag, previous_tag_size} = Serializer.serialize(segment, state.previous_tag_size)
 
-    actions = [
-      caps: {:output, %Membrane.RemoteStream{content_format: FLV}},
-      buffer: {:output, %Buffer{payload: tag}}
-    ]
-
+    actions = [buffer: {:output, %Buffer{payload: tag}}]
     state = Map.put(state, :previous_tag_size, previous_tag_size)
+
     {actions, state}
   end
 


### PR DESCRIPTION
Currently, the `caps` action is being sent with every single buffer in the FLV muxer. This shouldn't be required so I've changed it to only send them before the first outgoing buffer.