### PR TITLE
Add support for enhanced RTMP specification

### DIFF
--- a/lib/membrane_flv_plugin/parser.ex
+++ b/lib/membrane_flv_plugin/parser.ex
@@ -26,7 +26,9 @@ defmodule Membrane.FLV.Parser do
   def parse_header(_incorrect_data), do: {:error, :not_a_header}
 
   @spec parse_body(binary()) ::
-          {:ok, packets :: [Packet.t()], rest :: binary()} | {:error, :not_enough_data}
+          {:ok, packets :: [Packet.t()], rest :: binary()}
+          | {:error, :not_enough_data}
+          | {:error, {:unsupported_codec, atom()}}
   def parse_body(data) when byte_size(data) < 15, do: {:error, :not_enough_data}
 
   def parse_body(<<_head::40, data_size::24, _rest::binary>> = data)
@@ -57,28 +59,29 @@ defmodule Membrane.FLV.Parser do
         rest::binary
       >>) do
     type = resolve_type(type)
-    {type, codec, codec_params, payload} = parse_payload(type, payload)
 
-    dts = parse_timestamp(timestamp, timestamp_extended)
-    # if composition time is not set in codec_params, then we assume it's 0
-    pts = dts + Map.get(codec_params, :composition_time, 0)
+    with {:ok, {type, codec, codec_params, payload}} <- parse_payload(type, payload) do
+      dts = parse_timestamp(timestamp, timestamp_extended)
+      # if composition time is not set in codec_params, then we assume it's 0
+      pts = dts + Map.get(codec_params, :composition_time, 0)
 
-    packet = %Packet{
-      pts: pts,
-      dts: dts,
-      stream_id: stream_id,
-      type: type,
-      payload: payload,
-      codec: codec,
-      codec_params: codec_params
-    }
+      packet = %Packet{
+        pts: pts,
+        dts: dts,
+        stream_id: stream_id,
+        type: type,
+        payload: payload,
+        codec: codec,
+        codec_params: codec_params
+      }
 
-    case parse_body(rest) do
-      {:ok, packets, rest} ->
-        {:ok, [packet | packets], rest}
+      case parse_body(rest) do
+        {:ok, packets, rest} ->
+          {:ok, [packet | packets], rest}
 
-      {:error, :not_enough_data} ->
-        {:ok, [packet], rest}
+        {:error, :not_enough_data} ->
+          {:ok, [packet], rest}
+      end
     end
   end
 
@@ -91,7 +94,7 @@ defmodule Membrane.FLV.Parser do
          <<10::4, 3::2, _sound_size::1, 1::1, packet_type::8, payload::binary>>
        ) do
     type = if packet_type == 1, do: :audio, else: :audio_config
-    {type, :AAC, %{}, payload}
+    {:ok, {type, :AAC, %{}, payload}}
   end
 
   # everything else
@@ -118,7 +121,52 @@ defmodule Membrane.FLV.Parser do
         1 -> :stereo
       end
 
-    {:audio, codec, %{sound_rate: sound_rate, sound_type: sound_type}, payload}
+    {:ok, {:audio, codec, %{sound_rate: sound_rate, sound_type: sound_type}, payload}}
+  end
+
+  # extended rtmp specification: https://github.com/veovera/enhanced-rtmp
+  @keyframe_frame_type 1
+
+  @av1 <<"a", "v", "0", "1">>
+  @vp9 <<"v", "p", "0", "9">>
+  @hevc <<"h", "v", "c", "1">>
+  @ex_video_header <<1::1>>
+
+  @packet_type_sequence_start 0
+  @packet_type_coded_frames 1
+  # @packet_type_sequence_end 2
+  # @packet_type_codec_frames_x 3
+  @packet_type_metadata 4
+  @packet_type_mp4g2ts_sequence_start 5
+  defp parse_payload(:video, <<
+         @ex_video_header::bitstring,
+         frame_type::3,
+         packet_type::4,
+         video_four_cc::4-binary,
+         payload::binary
+       >>) do
+    type = ext_flv_packet_type(video_four_cc, packet_type)
+
+    {composition_time, payload} =
+      if video_four_cc == @hevc and packet_type == @packet_type_coded_frames do
+        <<composition_time::24, payload::binary>> = payload
+
+        {composition_time, payload}
+      else
+        {0, payload}
+      end
+
+    codec =
+      case video_four_cc do
+        @av1 -> :AV1
+        @vp9 -> :VP9
+        @hevc -> :HEVC
+      end
+
+    {:ok,
+     {type, codec,
+      %{composition_time: composition_time, key_frame?: frame_type == @keyframe_frame_type},
+      payload}}
   end
 
   # AVC H264
@@ -132,14 +180,33 @@ defmodule Membrane.FLV.Parser do
        >>) do
     type = if packet_type == 0, do: :video_config, else: :video
 
-    {type, :H264,
-     %{composition_time: composition_time, key_frame?: frame_type == @keyframe_frame_type},
-     payload}
+    {:ok,
+     {type, :H264,
+      %{composition_time: composition_time, key_frame?: frame_type == @keyframe_frame_type},
+      payload}}
   end
 
   defp parse_payload(:video, <<_frame_type::4, codec::4, _rest::binary>>) do
-    vcodec = FLV.index_to_video_codec(codec) |> inspect()
-    raise("Video codec #{vcodec} is not yet supported")
+    vcodec = FLV.index_to_video_codec(codec)
+    {:error, {:unsupported_codec, vcodec}}
+  end
+
+  defp ext_flv_packet_type(video_four_cc, packet_type) do
+    cond do
+      packet_type == @packet_type_metadata ->
+        # NOTE: payload for this packet type includes AMF encoded metadata
+        :video_config
+
+      video_four_cc == @av1 and
+          packet_type in [@packet_type_sequence_start, @packet_type_mp4g2ts_sequence_start] ->
+        :video_config
+
+      video_four_cc in [@hevc, @vp9] and packet_type == @packet_type_sequence_start ->
+        :video_config
+
+      true ->
+        :video
+    end
   end
 
   defp resolve_type(8), do: :audio


### PR DESCRIPTION
This PR adds support for [enhanced RTMP specification](https://github.com/veovera/enhanced-rtmp).

Even though we will not be handling the additional protocols (AV1, HEVC, VP9) we will notify the parent element about the unsupported codec instead (and eventually crashed if the notification doesn't get handled after 300 packets).

The motivation behind this PR is a recently merged [PR](https://github.com/obsproject/obs-studio/pull/8522) to OBS that adds support for the mentioned codecs by extending the FLV functionality.